### PR TITLE
Reload when attempting to fire while empty.

### DIFF
--- a/Assets/Weapons/Weapon.gd
+++ b/Assets/Weapons/Weapon.gd
@@ -65,7 +65,7 @@ func shoot(camera):
 				emit_signal("damage_dealt")
 				print(player.get_network_master())
 	else:
-		rpc("dry_fire")
+		reload()
 	
 	return current_rounds
 


### PR DESCRIPTION
It appears that issue #26 can be addressed by simply calling `reload()` in the case where `current_rounds` is not greater than 0.