### PR TITLE
30 - simple TextChat

### DIFF
--- a/Game/Assets/UI/HUD.gd
+++ b/Game/Assets/UI/HUD.gd
@@ -6,7 +6,7 @@ func update_ammo(var weapon, var amount):
 func updateHealth(health: int):
 	$Health/HealthBar.value = health
 	$Health/HealthBar/HealthText.text = String(health)
-	
+
 func update_crosshair(visible: bool, hit: bool):
 	$Crosshair.visible = visible
 	if hit:

--- a/Game/Assets/UI/HUD.tscn
+++ b/Game/Assets/UI/HUD.tscn
@@ -57,6 +57,7 @@ __meta__ = {
 }
 
 [node name="Health" parent="." instance=ExtResource( 2 )]
+mouse_filter = 2
 
 [node name="Weapon" type="MarginContainer" parent="."]
 anchor_left = 1.0
@@ -69,6 +70,7 @@ margin_right = -32.0
 margin_bottom = -32.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -90,6 +92,7 @@ margin_right = 116.0
 margin_bottom = 64.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 alignment = 1
 
 [node name="RoundsClips" type="Label" parent="Weapon/VBoxContainer"]
@@ -123,6 +126,7 @@ margin_left = -511.401
 margin_top = -301.225
 margin_right = 512.599
 margin_bottom = 298.775
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -132,6 +136,7 @@ margin_left = 512.0
 margin_top = 300.0
 margin_right = 512.0
 margin_bottom = 300.0
+mouse_filter = 2
 
 [node name="Line1" type="ColorRect" parent="Crosshair/CrosshairCenter"]
 margin_left = 8.0
@@ -139,6 +144,7 @@ margin_top = -1.0
 margin_right = 20.0
 margin_bottom = 1.0
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -150,6 +156,7 @@ margin_right = 20.0
 margin_bottom = 1.0
 rect_rotation = 90.0
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -161,6 +168,7 @@ margin_right = 20.0
 margin_bottom = 1.0
 rect_rotation = 180.0
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -172,6 +180,7 @@ margin_right = 20.0
 margin_bottom = 1.0
 rect_rotation = -90.0
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -182,6 +191,7 @@ margin_left = 512.0
 margin_top = 300.0
 margin_right = 512.0
 margin_bottom = 300.0
+mouse_filter = 2
 script = ExtResource( 3 )
 
 [node name="HitConfirmationSound" type="AudioStreamPlayer" parent="Crosshair/HitConfirmation"]
@@ -198,6 +208,7 @@ margin_bottom = 1.0
 rect_rotation = 45.3067
 rect_scale = Vector2( 1, 0.5 )
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -210,6 +221,7 @@ margin_bottom = 1.0
 rect_rotation = 135.307
 rect_scale = Vector2( 1, 0.5 )
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -222,6 +234,7 @@ margin_bottom = 1.0
 rect_rotation = 225.306
 rect_scale = Vector2( 1, 0.5 )
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -234,6 +247,7 @@ margin_bottom = 1.0
 rect_rotation = -44.6931
 rect_scale = Vector2( 1, 0.5 )
 rect_pivot_offset = Vector2( -8, 1 )
+mouse_filter = 2
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/Game/Classes/Player/Player.gd
+++ b/Game/Classes/Player/Player.gd
@@ -43,7 +43,7 @@ onready var active_weapon = weapons.switch_to_weapon(0)
 #onready var sfx_foosteps = [$"Sounds/Footstep-Concrete-01",
 #							$"Sounds/Footstep-Concrete-02",
 #							$"Sounds/Footstep-Concrete-03",
-#							$"Sounds/Footstep-Concrete-04"]	
+#							$"Sounds/Footstep-Concrete-04"]
 
 #var sfx_footsteps_last = 0
 #var sfx_footsteps_next = 0
@@ -88,17 +88,17 @@ remote func set_player_data(player):
 func get_closest_point(_A: Vector3, _B: Vector3):
 	var A = transform.inverse().xform(_A)
 	var B = transform.inverse().xform(_B)
-	
+
 	var diff = B - A
 	var result = A - (A.dot(diff) * diff) / (diff.length_squared())
 	return transform.xform(result)
 
 func on_bullet_flyby(from, to):
 	var closest_point = get_closest_point(from, to)
-	
+
 	var flyby_noise = preload("res://Classes/Audio/BulletFlyBySoundPlayer.tscn").instance()
 	flyby_noise.translation = closest_point
-	
+
 	get_tree().root.call_deferred("add_child", flyby_noise)
 
 remote func jump():
@@ -112,15 +112,15 @@ func jetpack(delta):
 	# Swap these to try the different versions of the jetpack.
 	#jetpack_grounded(delta)
 	#jetpack_empty(delta)
-	
+
 	# activate visual jetpack effects when sound is playing:
 	$Sounds/Jetpack.stream_paused = !jetpack_fireing
-	
+
 	$Effects/JetpackFlame.emitting = jetpack_fireing
 	$Effects/JetpackSmoke.emitting = jetpack_fireing
 	$Effects/JetpackLight.visible = jetpack_fireing
 	#print(get_tree().get_network_unique_id())
-	
+
 	#$Effects/JetpackFlame.emitting = ! $Sounds/Jetpack.stream_paused
 	#$Effects/JetpackSmoke.emitting = ! $Sounds/Jetpack.stream_paused
 	#$Effects/JetpackLight.visible = ! $Sounds/Jetpack.stream_paused
@@ -129,22 +129,22 @@ func jetpack_empty(delta):
 	debug.text = "JP fuel: %s\nJP active: %s\nJP used: %s\nJP sound: %s" % [
 		jetpack_fuel, jetpack_active, jetpack_used, !$Sounds/Jetpack.stream_paused
 	]
-	
+
 	# Enable jetpack when it is fully charged.
 	if jetpack_fuel > (JETPACK_FUEL_MAX - 0.001):
 		jetpack_used = false
 	# Disable jetpack when it is empty.
 	elif jetpack_fuel <= 0 and not jetpack_active:
 		jetpack_used = true
-	
+
 	if jetpack_active and not jetpack_used and jetpack_fuel > 0:
 		velocity.y += JETPACK_THRUST * delta
 		jetpack_fuel -= delta
-		
+
 		$Sounds/Jetpack.stream_paused = false
 	else:
 		$Sounds/Jetpack.stream_paused = true
-	
+
 	# Only charge when fully empty.
 	if jetpack_used:
 		jetpack_fuel = clamp(
@@ -158,7 +158,7 @@ func jetpack_grounded(delta):
 	debug.text = "JP fuel: %s\nJP active: %s\nJP sound: %s" % [
 		jetpack_fuel, jetpack_active, !$Sounds/Jetpack.stream_paused
 	]
-	
+
 	# Only charge when grounded.
 	if is_on_floor:
 		jetpack_fuel = clamp(
@@ -166,13 +166,13 @@ func jetpack_grounded(delta):
 			0.0,
 			JETPACK_FUEL_MAX
 		)
-		
+
 		jetpack_fireing = false
-	
+
 	# Only use jetpack in the air.
 	else:
 		if jetpack_active and jetpack_fuel > 0:
-			
+
 			velocity.y += JETPACK_THRUST * delta
 			jetpack_fuel -= delta
 			jetpack_fireing = true
@@ -187,42 +187,42 @@ remote func mouselook(rel):
 	var sensitivity = MOUSE_SENSITIVITY * game.mouse_sensitivity_multiplier
 	rotate_y(- rel.x * sensitivity)
 	camera.rotation.x = clamp(camera.rotation.x-rel.y * sensitivity, -PI/2, PI/2)
-	
+
 	rpc_unreliable("mouselook_abs", camera.rotation.x, rotation.y)
 
 func _physics_process(delta):
 	if get_parent().name != "Players":
 		return
-	
+
 	check_floor_collision()
-	
+
 	walk(delta)
 	fall(delta)
 	jetpack_grounded(delta)
-	
-	
+
+
 	if str(get_tree().get_network_unique_id()) != name:
 		return
-	
+
 	var movement_vector = Vector3()
 	if jump_timeout > 0:
 		movement_vector = move_and_slide(velocity, Vector3.UP)
 	else:
 		var upvector = floor_normal
 		movement_vector = move_and_slide_with_snap(velocity, Vector3.DOWN, upvector, true)
-		
+
 	velocity = movement_vector
-	
+
 	rset("translation", translation)
 
 func check_floor_collision():
 	var space_state = get_world().direct_space_state
-	
+
 	var from = global_transform.xform(Vector3(0, 0.0, 0))
 	var to = global_transform.xform(Vector3(0, -0.3, 0.0))
-	
+
 	var result  = space_state.intersect_ray(from, to)
-	
+
 	if jump_timeout > 0:
 		is_on_floor = false
 	elif result:
@@ -233,38 +233,39 @@ func check_floor_collision():
 
 func walk(delta):
 	jump_timeout -= delta
-	
+
 	# Walk
 	walk_direction = Vector2()
-	
-	if Input.is_action_pressed("MoveForward"):
-		walk_direction.y -= 1
-	if Input.is_action_pressed("MoveBack"):
-		walk_direction.y += 1
-	if Input.is_action_pressed("MoveLeft"):
-		walk_direction.x -= 1
-	if Input.is_action_pressed("MoveRight"):
-		walk_direction.x += 1
-	
+
+	if not get_tree().is_input_handled():
+		if Input.is_action_pressed("MoveForward"):
+			walk_direction.y -= 1
+		if Input.is_action_pressed("MoveBack"):
+			walk_direction.y += 1
+		if Input.is_action_pressed("MoveLeft"):
+			walk_direction.x -= 1
+		if Input.is_action_pressed("MoveRight"):
+			walk_direction.x += 1
+
 	walk_direction = walk_direction.normalized()
-	
+
 	var walking_speed = Vector2(velocity.x, velocity.z)
-	
+
 	walking_speed = walking_speed.rotated(rotation.y)
-	
+
 	if is_on_floor:
 		walking_speed = lerp(walking_speed, walk_direction * WALK_VELOCITY, delta * WALK_ACCEL)
 	else:
 		walking_speed = lerp(walking_speed, walk_direction * JUMP_VELOCITY, delta * JUMP_ACCEL)
 	walking_speed = walking_speed.rotated(-rotation.y)
-	
+
 	velocity.x = walking_speed.x
 	velocity.z = walking_speed.y
-	
+
 	# Make walking perpendicular to the floor
 	if is_on_floor:
 		velocity.y -= velocity.dot(floor_normal) / floor_normal.y
-	
+
 	if walking_speed.length() > 0 and is_on_floor:
 		weapon_bob_anim.travel("Walk")
 	elif walking_speed.length() == 0 and is_on_floor:
@@ -275,18 +276,18 @@ func fall(delta):
 	if is_on_floor:
 		if not was_on_floor: # if this is the first frame of ground conotact after a frame of no ground contact - we've just ended a fall
 			weapon_bob_anim.travel("Land")
-	
+
 	else:
 		velocity += delta * GRAVITY
-	
+
 	was_on_floor = is_on_floor
-	
+
 
 master func on_hit(damage, location):
 	set_health(health - 30)
-	
+
 	rpc("blood_splatter", location)
-	
+
 	if health <= 0:
 		rpc("kill")
 	else:
@@ -300,42 +301,42 @@ sync func blood_splatter(location):
 master func kill():
 	if is_dead:
 		return
-	
+
 	$Sounds/Death.rpc("play")
-	
+
 	is_dead = true
-	
+
 	set_health(0)
 	$CollisionShapeBody.disabled = true
-	
+
 	$Camera/Hand.hide()
 	#$HUD.update_crosshair(false, false)
-	
+
 	yield(get_tree().create_timer(3), "timeout")
-	
+
 	spawn()
-	
+
 	yield(get_tree().create_timer(3), "timeout")
-	
+
 #	for i in gibs.get_children():
 #		i.queue_free()
 #		yield(get_tree().create_timer(rand_range(0.1, 1)), "timeout")
-	
+
 #	gibs.queue_free()
 
 func spawn():
 	rpc("unset_death")
 	set_health(max_health)
-	
+
 	velocity = Vector3()
-	
+
 	game.get_spawn_point().spawn(self)
-	
+
 	$Camera/Hand.show()
 	$HUD.show()
-	
+
 	$CollisionShapeBody.disabled = false
-	
+
 	$Camera.rotation = Vector3.ZERO
 	rotation = Vector3.ZERO
 
@@ -357,39 +358,39 @@ sync func switch_to_next_weapon():
 sync func switch_to_prev_weapon():
 	active_weapon = weapons.prev_weapon()
 
-func _input(event):
+func _unhandled_input(event):
 	if is_dead:
 		return
-	
+
 	if str(get_tree().get_network_unique_id()) != name:
 		return
-	
+
 	if game.GAME_MODE != "PLAYING":
 		return
-	
+
 	# Moouselook
 	if event is InputEventMouseMotion:
 		var rel = event.relative
-		
+
 		mouselook(rel)
-	
+
 	# Jump
 	if event.is_action_pressed("MoveJump"):
 		rpc("jump")
 		jump()
-	
+
 	# Jetpack
 	if event.is_action_pressed("MoveJetpack"):
 		rpc("set_jetpack_active", true)
 	if event.is_action_released("MoveJetpack"):
 		rpc("set_jetpack_active", false)
-	
+
 	# Weapon
 	if event.is_action_pressed("WeaponPrimary"):
 		shoot()
 	if event.is_action_pressed("WeaponReload"):
 		reload()
-	
+
 	if event.is_action_pressed("WeaponNext"):
 		rpc("switch_to_next_weapon")
 	if event.is_action_pressed("WeaponPrev"):
@@ -407,30 +408,30 @@ func set_local_player():
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	$HUD/Health/HealthBar.max_value = max_health
-	
+
 	# Set player class
 	var path = get_script().get_path()
-	
+
 	if path.find("res://Assets/Characters/") != -1:
 		player_class = path.replace("res://Assets/Characters/", "").split("/")[0]
-	
+
 	set_health(max_health)
 	# disabled the ragdoll collider
 	#for i in $Player/Gibs.get_children():
 	#	i.get_child(1).disabled = true
 		#disabled = true
 		#$"Player/Gibs/PlayerGibs _cell /shape0".set_disabled(true)
-	
+
 	rset_config("translation", MultiplayerAPI.RPC_MODE_SYNC)
 	if !show_healthbar:
 		$Billboard.hide()
-	
+
 	# only show the debug label on local machine
 	if name != String(get_tree().get_network_unique_id()):
 		debug.hide()
-	
+
 	# initialize sound looping
-	
+
 	#$Sounds/Jetpack.stream.
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/Game/Classes/Player/Player.tscn
+++ b/Game/Classes/Player/Player.tscn
@@ -220,7 +220,7 @@ script = ExtResource( 8 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.53592, -0.0651628 )
 
 [node name="Hand" type="Spatial" parent="Camera"]
-transform = Transform( -4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0.335, -0.392298, -0.559 )
+transform = Transform( -4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0.335, -0.390282, -0.559 )
 
 [node name="WeaponBobAnimationTree" type="AnimationTree" parent="Camera/Hand"]
 tree_root = SubResource( 12 )
@@ -356,3 +356,4 @@ stream_paused = true
 
 [node name="HUD" parent="." instance=ExtResource( 7 )]
 visible = false
+mouse_filter = 2

--- a/Game/Classes/UI/CharacterSelect.gd
+++ b/Game/Classes/UI/CharacterSelect.gd
@@ -7,22 +7,22 @@ func _ready():
 	var dir = Directory.new()
 	dir.open("res://Assets/Characters/")
 	dir.list_dir_begin()
-	
+
 	var file = dir.get_next()
 	while file != "":
 		if not file.begins_with("."):
 			# Add character
 			add_character(file)
-		
+
 		file = dir.get_next()
 
 func add_character(character_name):
 	var path = "res://Assets/Characters/" + character_name + "/" + character_name + ".tscn"
 	var packed_character = load(path)
-	
+
 	var character_option = preload("res://Classes/UI/CharacterOption.tscn").instance()
 	$CenterContainer/VBoxContainer/CharacterList.add_child(character_option)
-	
+
 	character_option.set_character(packed_character)
 	character_option.connect("character_selected", self, "character_selected", [character_name, packed_character])
 

--- a/Game/Classes/UI/TextChat.gd
+++ b/Game/Classes/UI/TextChat.gd
@@ -1,0 +1,63 @@
+extends Control
+
+signal typing_toggled(is_typing)
+
+const TOGGLE_KEY = KEY_ENTER
+const MESSAGE_FORMAT = "%s: %s"
+
+sync var chat_text: = "" setget set_chat_text
+
+var player_name: = "Unknown"
+
+onready var line_edit: LineEdit = $LineEdit
+onready var chat_history: RichTextLabel = $Panel/ChatHistory
+
+func _input(event: InputEvent) -> void:
+	pass
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if is_typing():
+		get_tree().set_input_as_handled()
+
+	if event.is_action_pressed("ToggleChatWrite"):
+		toggle_typing()
+
+func toggle() -> bool:
+	visible = not visible
+
+	if not visible:
+		$LineEdit.hide()
+
+	return visible
+
+func toggle_typing() -> bool:
+	$LineEdit.visible = not $LineEdit.visible and visible
+
+	return $LineEdit.visible
+
+func is_typing() -> bool:
+	return $LineEdit.visible
+
+func _on_LineEdit_text_entered(new_text: String) -> void:
+	toggle_typing()
+	if new_text:
+		var formatted_message = MESSAGE_FORMAT % [player_name, new_text]
+		line_edit.text = ""
+		rset("chat_text", chat_text + formatted_message)
+
+func _on_LineEdit_visibility_changed() -> void:
+	if line_edit.visible:
+		line_edit.grab_focus()
+	else:
+		line_edit.release_focus()
+
+func set_chat_text(value: String) -> void:
+	visible = true
+	chat_text = "%s\n" % value
+	chat_history.text = chat_text
+
+
+func _on_LineEdit_gui_input(event: InputEvent) -> void:
+	get_tree().set_input_as_handled()
+	pass

--- a/Game/Classes/UI/TextChat.tscn
+++ b/Game/Classes/UI/TextChat.tscn
@@ -1,0 +1,51 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Classes/UI/TextChat.gd" type="Script" id=1]
+
+[node name="TextChat" type="Control"]
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_left = 8.0
+margin_top = -192.0
+margin_right = 200.0
+margin_bottom = -8.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Panel" type="Panel" parent="."]
+self_modulate = Color( 1, 1, 1, 0.670588 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_bottom = -32.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ChatHistory" type="RichTextLabel" parent="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 8.0
+margin_top = 8.0
+margin_right = -8.0
+margin_bottom = -8.0
+text = "
+"
+scroll_following = true
+selection_enabled = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LineEdit" type="LineEdit" parent="."]
+visible = false
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -24.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+[connection signal="text_entered" from="LineEdit" to="." method="_on_LineEdit_text_entered"]
+[connection signal="visibility_changed" from="LineEdit" to="." method="_on_LineEdit_visibility_changed"]

--- a/Game/Game.tscn
+++ b/Game/Game.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://Classes/UI/theme.tres" type="Theme" id=1]
 [ext_resource path="res://Game.gd" type="Script" id=2]
 [ext_resource path="res://Assets/Maps/DM1/DM1.tscn" type="PackedScene" id=3]
 [ext_resource path="res://Classes/UI/CharacterSelect.tscn" type="PackedScene" id=4]
 [ext_resource path="res://PlayerListContainer.gd" type="Script" id=5]
+[ext_resource path="res://Classes/UI/TextChat.tscn" type="PackedScene" id=6]
 
 [node name="Game" type="Node"]
 script = ExtResource( 2 )
@@ -317,6 +318,11 @@ theme = ExtResource( 1 )
 [node name="PlayerList" type="VBoxContainer" parent="PlayerListContainer/Panel"]
 theme = ExtResource( 1 )
 alignment = 1
+
+[node name="TextChat" parent="." instance=ExtResource( 6 )]
+visible = false
+margin_top = -264.542
+margin_bottom = -80.5416
 [connection signal="pressed" from="MenuContainer/MainMenu/QuickConnect" to="." method="join_test_server"]
 [connection signal="pressed" from="MenuContainer/MainMenu/Connect" to="." method="open_menu" binds= [ "ConnectMenu" ]]
 [connection signal="pressed" from="MenuContainer/MainMenu/Disconnect" to="." method="free_client"]
@@ -339,5 +345,6 @@ alignment = 1
 [connection signal="value_changed" from="MenuContainer/ControlsMenu/HBoxContainer/SensitivitySlider" to="." method="set_mouse_sensitivity"]
 [connection signal="pressed" from="MenuContainer/GraphicsMenu/Back" to="." method="return_to_menu" binds= [ "OptionsMenu" ]]
 [connection signal="toggled" from="MenuContainer/GraphicsMenu/Fullscreen" to="." method="set_fullscreen"]
+[connection signal="typing_toggled" from="TextChat" to="." method="_on_TextChat_typing_toggled"]
 
 [editable path="MenuContainer/CharacterSelectScreen"]

--- a/Game/PlayerListContainer.gd
+++ b/Game/PlayerListContainer.gd
@@ -4,12 +4,12 @@ var tracked_players = []
 
 func update_player_list():
 	var players = get_parent().get_node("Players").get_children()
-	
+
 	for child in $Panel/PlayerList.get_children():
 		$Panel/PlayerList.remove_child(child)
-	
+
 	for player in players:
 		var player_list_item = preload("res://Classes/UI/PlayerListItem.tscn").instance()
 		$Panel/PlayerList.add_child(player_list_item)
 		player_list_item.player = player
-	
+

--- a/Game/project.godot
+++ b/Game/project.godot
@@ -104,6 +104,16 @@ WeaponPrev={
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":5,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+ToggleChatWrite={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ToggleChatVisibility={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":89,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [rendering]
 


### PR DESCRIPTION
Solves #30 

Implements a simple TextChat that uses a `sync` variable to fill a chat history.

Features:
* Open chat history with `Y`
* Start typing with `enter`
* Send message/stop typing with `enter`
* Close chat history with `y`
* Auto opens with a new message.

Other changes:

Now the player input is in an `_inhandled_input` callback instead of `_input`. We usually have to do this so any Control node that captures an input prevents the player from moving. Also, in the function `walk` we check if the input was handled before.

The `LineEdit` should mark ALL keyboard inputs as handled before they get to the player node, but it doesn't happen consistently. So I had to make a workaround marking them manually in the `_unhandled_input` in the TextChat script.

Now that the player input is under `_unhandled_input` I had to set the mouse filter as ignore for the player HUD and children because they were handling mouse moves.

Current state:
https://user-images.githubusercontent.com/15899938/114277808-30d86700-9a03-11eb-8013-77f3d3830f60.mp4

